### PR TITLE
Improvement to the dbrowse Script

### DIFF
--- a/src/dbrowse
+++ b/src/dbrowse
@@ -126,6 +126,7 @@ Options:
 -cf|--copy-file │ Copy a line from the contents of the selection
  -p|--program   │ Open the appropriate program for the selection
  -h|--help	│ Print this help message and exit
+
 When no arguments are supplied, the target and prompt will be the working directory, and the program option will be used.
 \n"
 }

--- a/src/dbrowse
+++ b/src/dbrowse
@@ -1,29 +1,166 @@
 #!/bin/sh
 # TODO: multisel
 
-target="$1"
-[ -z "$target" ] && target="$(realpath .)"
-prompt="$2"
+main() {
+    parse_opts "$@"
+    
+    { [ -n "$help" ] && help; } ||
+    { [ -n "$raw" ] && prompt_raw "$@"; } ||
+    { [ -n "$copy" ] && prompt_copy "$@"; } ||
+    { [ -n "$copy_file" ] && prompt_copy_file "$@"; } ||
+    { [ -n "$program" ] && prompt_program "$@"; } ||
+    { prompt_program "$@"; } 
+}
 
-while true; do
-	p="$prompt"
-	[ -z "$p" ] && p="$target"
-	sel="$(ls -1a "$target" |grep -v '^\.$' | dmenu -p "$p" -l 25)"
-	ec=$?
-	[ "$ec" -ne 0 ] && exit $ec
+prompt_prep() {
+    target="$2"
+    [ -z "$target" ] && target="$(pwd)"
+    prompt="$3"
+}
 
-	c="$(echo "$sel" |cut -b1)"
-	if [ "$c" = "/" ]; then
-		newt="$sel"
-	else
-		newt="$(realpath "${target}/${sel}")"
-	fi
+prompt_base() {
+    p="$prompt"
+    [ -z "$p" ] && p="$(printf "$target" | sed 's|/home/amarakon|~|')"
+    sel="$(printf "$(ls "$target"; ls -A "$target" | grep '^\.' )" | dmenu -p "$p" -i -l 10)"
+    ec=$?
+    [ "$ec" -ne 0 ] && exit $ec
+
+    c="$(echo "$sel" | cut -b1)"
+    if [ "$c" = "/" ]; then
+	newt="$sel"
+    else
+	newt="$(realpath -s "${target}/${sel}")"
+    fi
+}
+
+prompt_raw() {
+    prompt_prep "$@"
+    while true; do
+	prompt_base "$@"
 
 	if [ -e "$newt" ]; then
-		target="$newt"
-		if [ ! -d "$target" ]; then
-			echo "$target"
-			exit 0
+	    target="$newt"
+	if [ ! -d "$target" ]; then
+	    echo "$target"			
+	    exit 0
+	fi
+	fi
+done
+}
+
+prompt_copy() {
+    prompt_prep "$@"
+    while true; do
+	prompt_base "$@"
+
+	if [ -e "$newt" ]; then
+	    target="$newt"
+
+	    if [ ! -d "$target" ]; then		
+		data2="$(file -b "$target" | cut -d ',' -f1 | cut -d ' ' -f2)"
+		data3="$(file -b "$target" | cut -d ',' -f2 | cut -d ' ' -f3)"
+
+		{ [ "$data2" = "image" ] && program="xclip -i -selection clipboard -t image/png"; } ||
+		{ [ "$data2" = "text" ] && program="xclip -r -i -selection clipboard"; } ||
+		{ [ "$data3" = "text" ] && program="xclip -r -i -selection clipboard"; }
+
+		{ [ -n "${program+1}" ] && $program "$target"; } ||
+		{ echo "Failed to recognize file format"; }
+		exit 0
 		fi
 	fi
 done
+}
+
+prompt_copy_file() {
+    prompt_prep "$@"
+    while true; do
+	prompt_base "$@"
+
+	if [ -e "$newt" ]; then
+	    target="$newt"
+
+	    if [ ! -d "$target" ]; then		
+		cat "$target" | dmenu -i -l 10 | xclip -r -i -selection clipboard
+		exit 0
+		fi
+	fi
+done
+}
+
+prompt_program() {
+    prompt_prep "$@"
+    while true; do
+	prompt_base "$@"
+
+	if [ -e "$newt" ]; then
+	    target="$newt"
+
+	    if [ ! -d "$target" ]; then		
+		data="$(file -b "$target" | cut -d ',' -f1 | cut -d ' ' -f1)"
+		data2="$(file -b "$target" | cut -d ',' -f1 | cut -d ' ' -f2)"
+		data3="$(file -b "$target" | cut -d ',' -f2 | cut -d ' ' -f3)"
+
+		{ [ "$data" = "Matroska" ] && program="$PLAYER"; } ||
+		{ [ "$data2" = "audio" ] && program="$TERMINAL -e $PLAYER"; } ||
+		{ [ "$data2" = "document" ] && program="$READER"; } ||
+		{ [ "$data2" = "Word" ] && program="$OFFICE"; } ||
+		{ [ "$data2" = "image" ] && program="$VIEWER"; } ||
+		{ [ "$data2" = "text" ] && program="$TERMINAL -e $EDITOR"; } ||
+		{ [ "$data3" = "text" ] && program="$TERMINAL -e $EDITOR"; }
+
+		{ [ -n "${program+1}" ] && $program "$target"; } ||
+		{ echo "Failed to recognize file format"; }
+		exit 0
+		fi
+	fi
+done
+}
+
+help() {
+    printf "Usage:	dfm [options] [target] [prompt]
+
+Options:
+ -r|--raw       │ Get the raw output of the selection
+ -c|--copy      │ Copy the contents of the selection
+-cf|--copy-file │ Copy a line from the contents of the selection
+ -p|--program   │ Open the appropriate program for the selection
+ -h|--help	│ Print this help message and exit
+When no arguments are supplied, the target and prompt will be the working directory, and the program option will be used.
+\n"
+}
+
+parse_opts() {
+    while [ $# -gt 0 ]; do
+        key="$1"
+        
+	case $key in
+	-h|--help)
+	    help=1
+	    shift
+	    ;;
+	-r|--raw)
+	    raw=1
+	    shift
+	    ;;
+	-c|--copy)
+	    copy=1
+	    shift
+	    ;;
+	-cf|--copy-file)
+	    copy_file=1
+	    shift
+	    ;;
+	-p|--program)
+	    program=1
+	    shift
+	    ;;
+	*)
+	    shift
+	    ;;
+	esac
+
+    done
+}
+
+main "$@"


### PR DESCRIPTION
I added useful options to the dbrowse script to make it a suckless file manager.
The main feature of it is that you can pass the `-p` or `--program` option to open the default program for the selection.
For example, if you select a `.png` file, your default image viewer will be used.
The `-c` or `--copy` option allows you to copy the contents of a file.
The `-cf` or `--copy-file` option allows you to copy a specific line.
Here is the help message invoked by running `dbrowse -h` or `dbrowse --help`:

```
Usage:	dfm [options] [target] [prompt]

Options:
 -r|--raw       │ Get the raw output of the selection
 -c|--copy      │ Copy the contents of the selection
-cf|--copy-file │ Copy a line from the contents of the selection
 -p|--program   │ Open the appropriate program for the selection
 -h|--help	│ Print this help message and exit

When no arguments are supplied, the target and prompt will be the working directory, and the program option will be used.

```